### PR TITLE
Add settings to keep display on indefinitely

### DIFF
--- a/template/desktops/xfce.sh
+++ b/template/desktops/xfce.sh
@@ -19,6 +19,39 @@ xfconf-query -c xfce4-session -p /startup/ssh-agent/enabled -n -t bool -s false
 xfconf-query -c xfce4-session -p /startup/gpg-agent/enabled -n -t bool -s false
 echo "TIMING: $(date -Iseconds) - Disabled startup services"
 
+# Turn off power saving measures that turn off the display
+xfconf-query \
+    --channel xfce4-power-manager \
+    --property /xfce4-power-manager/dpms-enabled \
+    --create \
+    --type bool \
+    --set true
+
+xfconf-query \
+    --channel xfce4-power-manager \
+    --property /xfce4-power-manager/dpms-on-ac-off \
+    --create \
+    --set 0 \
+    --type uint
+
+xfconf-query \
+    --channel xfce4-power-manager \
+    --property /xfce4-power-manager/dpms-on-ac-sleep \
+    --create \
+    --set 0 \
+    --type uint
+
+xfconf-query \
+    --channel xfce4-power-manager \
+    --property /xfce4-power-manager/blank-on-ac \
+    --create \
+    --set 0 \
+    --type int
+
+# Show the power management settings in output
+echo "xfconf-query settings for xfce-power-manager:"
+xfconf-query --channel xfce4-power-manager --list --verbose
+
 # Disable useless services on autostart
 AUTOSTART="${HOME}/.config/autostart"
 rm -fr "${AUTOSTART}"    # clean up previous autostarts

--- a/template/desktops/xfce.sh
+++ b/template/desktops/xfce.sh
@@ -20,6 +20,8 @@ xfconf-query -c xfce4-session -p /startup/gpg-agent/enabled -n -t bool -s false
 echo "TIMING: $(date -Iseconds) - Disabled startup services"
 
 # Turn off power saving measures that turn off the display
+# See https://github.com/Harvard-ATG/ood-remote-desktop/pull/4
+# for additional context on these options
 xfconf-query \
     --channel xfce4-power-manager \
     --property /xfce4-power-manager/dpms-enabled \


### PR DESCRIPTION
After a lot of joint troubleshooting, these changes to the startup script should keep the display awake indefinitely, resolving the issue where the desktop goes black after an extended period of inactivity.

References:
- [Pointer to the xfconf-query command for setting options](https://askubuntu.com/a/407298)
- [Pointer to correct type for `dpms-on-ac-off` and `dpms-on-ac-sleep` settings](https://gitlab.xfce.org/xfce/xfce4-power-manager/-/issues/178)
- [xfconf-query command reference](https://docs.xfce.org/xfce/xfconf/xfconf-query)
- [Source code with xfconf-query types](https://gitlab.xfce.org/xfce/xfce4-power-manager/-/blob/master/src/xfpm-xfconf.c#L235)

Fixes #2 