### PR TITLE
Bind shared folder dir

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -24,6 +24,7 @@ echo "TIMING: $(date -Iseconds) - Loaded environment"
 container_image=/shared/apptainerImages/<%= context.desktop %>.sif
 
 export SING_BINDS=""
+export SING_BINDS="$SING_BINDS -B /shared/courseSharedFolders"
 # export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
 # export SING_BINDS="$SING_BINDS -B /etc/sssd/"
 # export SING_BINDS="$SING_BINDS -B /var/lib/sss"


### PR DESCRIPTION
If this isn't done, shared folders are visible, but the destination of the sym link doesn't exist, so trying to access the shared folder from inside a container fails.