### PR TITLE
Updates for AL 2023 infrastructure

### DIFF
--- a/build/xfce.def
+++ b/build/xfce.def
@@ -16,7 +16,6 @@ DEBIAN_FRONTEND=noninteractive apt install -y \
     libosmesa6-dev \
     locales \
     xfce4-terminal \
-    # firefox \ # needs to be installed via snap
     vim \
     language-pack-en-base
 dpkg-reconfigure locales

--- a/build/xfce.def
+++ b/build/xfce.def
@@ -17,5 +17,6 @@ DEBIAN_FRONTEND=noninteractive apt install -y \
     locales \
     xfce4-terminal \
     vim \
-    language-pack-en-base
+    language-pack-en-base \
+    git
 dpkg-reconfigure locales

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -25,12 +25,12 @@ container_image=/shared/apptainerImages/<%= context.desktop %>.sif
 
 # Bind folders to the container file system so it can access and write to them
 SING_BIND_LIST=(
-  "-B" "/shared/courseSharedFolders"
-  "-B" "/shared/spack"
-  "-B" "$WORKING_DIR/etc/rstudio:/etc/rstudio"
+  "-B" "/shared"
 )
 SING_BINDS="${SING_BIND_LIST[@]}"
 log "SING_BINDS=${SING_BINDS}"
+
+unset DBUS_SESSION_BUS_ADDRESS
 
 log "Launching desktop <%= context.desktop %>"
 


### PR DESCRIPTION
# Overview

This PR fixes the generic remote desktop app to work in the new infrastructure set up in the summer of 2025.

For testing, this app will work in the prod environment under a personal ood app dev folder.

# Changes

- Remove commented firefox install line, it was preventing packages below it from installing
- Add git to the container - required for spack to work
- Mount `/shared` directly, rather than subfolders, to ensure software installed there works consistently
- Unset an environment variable to address an error in the logs that prevented the app starting, as recommended in a forum post.

# References

- [Open OnDemand Discourse Forum Post](https://discourse.openondemand.org/t/failed-to-init-libxfconf-could-not-connect-no-such-file-or-directory-on-ood-1-8-20-and-red-hat-8/1543) - had the fix with unsetting an environment variable.